### PR TITLE
Added start option for getTicker method

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Get ticker information
 **Parameters**
 
 -   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Options for the request:
+    -   `options.start` **Int?** Return results from rank start and above
     -   `options.limit` **Int?** Only returns the top limit results
     -   `options.convert` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Return price, 24h volume, and market cap in terms of another currency
     -   `options.currency` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Return only specific currency
@@ -99,6 +100,7 @@ const client = new CoinMarketCap()
 client.getTicker({limit: 3}).then(console.log).catch(console.error)
 client.getTicker({limit: 1, currency: 'bitcoin'}).then(console.log).catch(console.error)
 client.getTicker({convert: 'EUR'}).then(console.log).catch(console.error)
+client.getTicker({start: 0, limit: 5}).then(console.log).catch(console.error)
 ```
 
 ### getGlobal

--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ class CoinMarketCap {
      * Get ticker information
      *
      * @param {Object=} options Options for the request:
-     * @param {Int=} options.limit  Only returns the top limit results
+     * @param {Int=} options.start  Return results from rank start + 1 and above
+     * @param {Int=} options.limit  Only returns limit number of results
      * @param {String=} options.convert  Return price, 24h volume, and market cap in terms of another currency
      * @param {String=} options.currency  Return only specific currency
      *
@@ -27,12 +28,13 @@ class CoinMarketCap {
      * client.getTicker({limit: 3}).then(console.log).catch(console.error)
      * client.getTicker({limit: 1, currency: 'bitcoin'}).then(console.log).catch(console.error)
      * client.getTicker({convert: 'EUR'}).then(console.log).catch(console.error)
+     * client.getTicker({start: 0, limit: 5}).then(console.log).catch(console.error)
      */
-  getTicker ({ limit, convert, currency }) {
+  getTicker ({ start, limit, convert, currency }) {
     return createRequest({
       url: `${this.url}/ticker${currency ? `/${currency}`.toLowerCase() : ''}`,
       headers: this.headers,
-      query: { convert, limit }
+      query: { start, convert, limit }
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
   "devDependencies": {
     "husky": "^0.14.3",
     "jest": "^22.0.0",
-    "prettier-standard": "^8.0.0"
-    "jest": "^22.0.0",
     "prettier-standard": "^7.0.1"
   },
   "dependencies": {


### PR DESCRIPTION
The CoinMarketCap API has an option for its ticker API call to get results starting from a specific rank, so I added an optional start parameter to the getTicker method in index.js. I modified the README file to reflect the addition of the start option.

The package file got changed after I called npm install in the directory.