### PR TITLE
Breaking changes: Switching wrapper from public API to free tier of professional API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 > CoinMarketCap API wrapper for node
 
+This wrapper is based on the free tier of [the CoinMarketCap Professional API](https://pro.coinmarketcap.com/api/v1#section/Introduction).
+You can get your API key [here](https://pro.coinmarketcap.com/pricing).
+
 ## Table of Contents
 
 -   [Install](#install)
@@ -26,9 +29,10 @@ $ yarn add coinmarketcap-api
 ```js
 const CoinMarketCap = require('coinmarketcap-api')
 
-const client = new CoinMarketCap()
+const apiKey = 'api key'
+const client = new CoinMarketCap(apiKey)
 
-client.getTicker().then(console.log).catch(console.error)
+client.getTickers().then(console.log).catch(console.error)
 client.getGlobal().then(console.log).catch(console.error)
 ```
 
@@ -41,57 +45,114 @@ Check out the [CoinMarketCap API documentation](https://coinmarketcap.com/api/) 
 #### Table of Contents
 
 -   [constructor](#constructor)
--   [getListings](#getlistings)
--   [getTicker](#getticker)
+-   [getIdMap](#getidmap)
+-   [getMetadata](#getmetadata)
+-   [getTickers](#gettickers)
+-   [getQuotes](#getquotes)
 -   [getGlobal](#getglobal)
 
 ### constructor
 
 **Parameters**
 
+-   `apiKey` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** API key for accessing the CoinMarketCap API
 -   `Options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Options for the CoinMarketCap instance (optional, default `{}`)
-    -   `Options.version`   (optional, default `'v2'`)
+    -   `Options.version`   (optional, default `'v1'`)
     -   `Options.fetcher`   (optional, default `fetch`)
     -   `Options.config`   (optional, default `{}`)
 
-### getListings
+### getIdMap
 
-Get all active cryptocurrency listings
+Get a paginated list of all cryptocurrencies by CoinMarketCap ID.
+
+**Parameters**
+
+-   `args`   (optional, default `{}`)
+-   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Options for the request:
+    -   `options.listing_status` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** active or inactive coins (optional, default `"active"`)
+    -   `options.start` **([Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number) \| [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** Return results from rank start and above (optional, default `1`)
+    -   `options.limit` **([Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number) \| [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))?** Only returns limit number of results
+    -   `options.symbol` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)> | [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))?** Comma separated list of symbols, will ignore the other options
 
 **Examples**
 
 ```javascript
-const client = new CoinMarketCap()
-client.getListings().then(console.log).catch(console.error)
+const client = new CoinMarketCap('api key')
+client.getIdMap().then(console.log).catch(console.error)
+client.getIdMap({listing_status: 'inactive', limit: 10}).then(console.log).catch(console.error)
+client.getIdMap({symbol: 'BTC,ETH'}).then(console.log).catch(console.error)
+client.getIdMap({symbol: ['BTC', 'ETH']}).then(console.log).catch(console.error)
 ```
 
-### getTicker
+### getMetadata
 
-Get ticker information.
+Get static metadata for one or more cryptocurrencies.
+Either id or symbol is required, but passing in both is not allowed.
+
+**Parameters**
+
+-   `args`   (optional, default `{}`)
+-   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Options for the request:
+    -   `options.id` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array) \| [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number))?** One or more comma separated cryptocurrency IDs
+    -   `options.symbol` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)> | [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** One or more comma separated cryptocurrency symbols
+
+**Examples**
+
+```javascript
+const client = new CoinMarketCap('api key')
+client.getMetadata({id: '1'}).then(console.log).catch(console.error)
+client.getMetadata({id: [1, 2]}).then(console.log).catch(console.error)
+client.getMetadata({symbol: 'BTC,ETH'}).then(console.log).catch(console.error)
+client.getMetadata({symbol: ['BTC', 'ETH]}).then(console.log).catch(console.error)
+```
+
+### getTickers
+
+Get information on all tickers.
 Start and limit options can only be used when currency or ID is not given.
 Currency and ID cannot be passed in at the same time.
 
 **Parameters**
 
 -   `args`   (optional, default `{}`)
--   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Options for the request:
-    -   `options.start` **([Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number) \| [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))?** Return results from rank start and above
-    -   `options.limit` **([Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number) \| [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))?** Only returns limit number of results
-    -   `options.sort` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Sort results by id, rank, volume_24h, or percent_change_24h (default is rank)
-    -   `options.structure` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Specify the structure for the main data field. Possible values are dictionary and array (default is dictionary).
-    -   `options.convert` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Return price, 24h volume, and market cap in terms of another currency
-    -   `options.currency` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Return only specific currency
-    -   `options.id` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Return only specific currency associated with its ID from listings
+-   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Options for the request
+    -   `options.start` **([Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number) \| [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** Return results from rank start and above (optional, default `1`)
+    -   `options.limit` **([Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number) \| [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** Only returns limit number of results [1..5000] (optional, default `100`)
+    -   `options.convert` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)> | [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** Return info in terms of another currency (optional, default `"USD"`)
+    -   `options.sort` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Sort results by the options at <https://pro.coinmarketcap.com/api/v1#operation/getV1CryptocurrencyListingsLatest> (optional, default `"market_cap"`)
+    -   `options.sort_dir` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Direction in which to order cryptocurrencies ("asc" | "desc")
+    -   `options.cryptocurrency_type` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Type of cryptocurrency to include ("all" | "coins" | "tokens") (optional, default `"all"`)
 
 **Examples**
 
 ```javascript
-const client = new CoinMarketCap()
-client.getTicker({limit: 3}).then(console.log).catch(console.error)
-client.getTicker({convert: 'EUR'}).then(console.log).catch(console.error)
-client.getTicker({start: 0, limit: 5}).then(console.log).catch(console.error)
-client.getTicker({currency: 'BTC'}).then(console.log).catch(console.error)
-client.getTicker({convert: 'JPY', id: 2}).then(console.log).catch(console.error)
+const client = new CoinMarketCap('api key')
+client.getTickers({limit: 3}).then(console.log).catch(console.error)
+client.getTickers({convert: 'EUR'}).then(console.log).catch(console.error)
+client.getTickers({start: 0, limit: 5}).then(console.log).catch(console.error)
+client.getTickers({sort: 'name'}).then(console.log).catch(console.error)
+```
+
+### getQuotes
+
+Get latest market quote for 1 or more cryptocurrencies.
+
+**Parameters**
+
+-   `args`   (optional, default `{}`)
+-   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Options for the request:
+    -   `options.id` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array) \| [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number))?** One or more comma separated cryptocurrency IDs
+    -   `options.symbol` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)> | [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))?** One or more comma separated cryptocurrency symbols
+    -   `options.convert` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)> | [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** Return quotes in terms of another currency (optional, default `"USD"`)
+
+**Examples**
+
+```javascript
+const client = new CoinMarketCap('api key')
+client.getQuotes({id: '1'}).then(console.log).catch(console.error)
+client.getQuotes({id: [1, 2], convert: 'USD,EUR'}).then(console.log).catch(console.error)
+client.getQuotes({symbol: 'BTC,ETH'}).then(console.log).catch(console.error)
+client.getQuotes({symbol: ['BTC', 'ETH]}).then(console.log).catch(console.error)
 ```
 
 ### getGlobal
@@ -101,8 +162,8 @@ Get global information
 **Parameters**
 
 -   `convert`  
--   `options` **([Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object) \| [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))?** Options for the request
-    -   `options.convert` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Return price, 24h volume, and market cap in terms of another currency
+-   `options` **([Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)> | [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))?** Options for the request:
+    -   `options.convert` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)> | [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** Return quotes in terms of another currency (optional, default `"USD"`)
 
 **Examples**
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset='utf-8' />
-  <title>coinmarketcap-api 2.3.1 | Documentation</title>
+  <title>coinmarketcap-api 2.3.2 | Documentation</title>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' type='text/css' rel='stylesheet' />
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
@@ -14,7 +14,7 @@
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>coinmarketcap-api</h3>
-          <div class='mb1'><code>2.3.1</code></div>
+          <div class='mb1'><code>2.3.2</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
@@ -35,9 +35,9 @@
               
                 
                 <li><a
-                  href='#getlistings'
+                  href='#getidmap'
                   class="">
-                  getListings
+                  getIdMap
                   
                 </a>
                 
@@ -45,9 +45,29 @@
               
                 
                 <li><a
-                  href='#getticker'
+                  href='#getmetadata'
                   class="">
-                  getTicker
+                  getMetadata
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#gettickers'
+                  class="">
+                  getTickers
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#getquotes'
+                  class="">
+                  getQuotes
                   
                 </a>
                 
@@ -88,7 +108,7 @@
 
   
 
-  <div class='pre p1 fill-light mt0'>constructor(Options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</div>
+  <div class='pre p1 fill-light mt0'>constructor(apiKey: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>, Options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</div>
   
   
 
@@ -102,6 +122,15 @@
   
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>apiKey</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+	    API key for accessing the CoinMarketCap API
+
+          </div>
+          
+        </div>
       
         <div class='space-bottom0'>
           <div>
@@ -127,7 +156,7 @@
                 <tr>
   <td class='break-word'><span class='code bold'>Options.version</span> <code class='quiet'>any</code>
   
-    (default <code>&#39;v2&#39;</code>)
+    (default <code>&#39;v1&#39;</code>)
   </td>
   <td class='break-word'><span></span></td>
 </tr>
@@ -185,74 +214,18 @@
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='getlistings'>
-      getListings
+    <h3 class='fl m0' id='getidmap'>
+      getIdMap
     </h3>
     
     
   </div>
   
 
-  <p>Get all active cryptocurrency listings</p>
+  <p>Get a paginated list of all cryptocurrencies by CoinMarketCap ID.</p>
 
 
-  <div class='pre p1 fill-light mt0'>getListings()</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> client = <span class="hljs-keyword">new</span> CoinMarketCap()
-client.getListings().then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)</pre>
-    
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-            <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='getticker'>
-      getTicker
-    </h3>
-    
-    
-  </div>
-  
-
-  <p>Get ticker information.
-Start and limit options can only be used when currency or ID is not given.
-Currency and ID cannot be passed in at the same time.</p>
-
-
-  <div class='pre p1 fill-light mt0'>getTicker(args: any, options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</div>
+  <div class='pre p1 fill-light mt0'>getIdMap(args: any, options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</div>
   
   
 
@@ -297,7 +270,20 @@ Currency and ID cannot be passed in at the same time.</p>
             <tbody class='mt1'>
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.start</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)?</code>
+  <td class='break-word'><span class='code bold'>options.listing_status</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></code>
+  
+    (default <code>&quot;active&quot;</code>)
+  </td>
+  <td class='break-word'><span>active or inactive coins
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.start</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+  
+    (default <code>1</code>)
   </td>
   <td class='break-word'><span>Return results from rank start and above
 </span></td>
@@ -315,45 +301,9 @@ Currency and ID cannot be passed in at the same time.</p>
 
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.sort</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?</code>
+  <td class='break-word'><span class='code bold'>options.symbol</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)?</code>
   </td>
-  <td class='break-word'><span>Sort results by id, rank, volume_24h, or percent_change_24h (default is rank)
-</span></td>
-</tr>
-
-
-              
-                <tr>
-  <td class='break-word'><span class='code bold'>options.structure</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?</code>
-  </td>
-  <td class='break-word'><span>Specify the structure for the main data field. Possible values are dictionary and array (default is dictionary).
-</span></td>
-</tr>
-
-
-              
-                <tr>
-  <td class='break-word'><span class='code bold'>options.convert</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?</code>
-  </td>
-  <td class='break-word'><span>Return price, 24h volume, and market cap in terms of another currency
-</span></td>
-</tr>
-
-
-              
-                <tr>
-  <td class='break-word'><span class='code bold'>options.currency</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?</code>
-  </td>
-  <td class='break-word'><span>Return only specific currency
-</span></td>
-</tr>
-
-
-              
-                <tr>
-  <td class='break-word'><span class='code bold'>options.id</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>?</code>
-  </td>
-  <td class='break-word'><span>Return only specific currency associated with its ID from listings
+  <td class='break-word'><span>Comma separated list of symbols, will ignore the other options
 </span></td>
 </tr>
 
@@ -377,12 +327,417 @@ Currency and ID cannot be passed in at the same time.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> client = <span class="hljs-keyword">new</span> CoinMarketCap()
-client.getTicker({<span class="hljs-attr">limit</span>: <span class="hljs-number">3</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
-client.getTicker({<span class="hljs-attr">convert</span>: <span class="hljs-string">'EUR'</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
-client.getTicker({<span class="hljs-attr">start</span>: <span class="hljs-number">0</span>, <span class="hljs-attr">limit</span>: <span class="hljs-number">5</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
-client.getTicker({<span class="hljs-attr">currency</span>: <span class="hljs-string">'BTC'</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
-client.getTicker({<span class="hljs-attr">convert</span>: <span class="hljs-string">'JPY'</span>, <span class="hljs-attr">id</span>: <span class="hljs-number">2</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)</pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> client = <span class="hljs-keyword">new</span> CoinMarketCap(<span class="hljs-string">'api key'</span>)
+client.getIdMap().then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
+client.getIdMap({<span class="hljs-attr">listing_status</span>: <span class="hljs-string">'inactive'</span>, <span class="hljs-attr">limit</span>: <span class="hljs-number">10</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
+client.getIdMap({<span class="hljs-attr">symbol</span>: <span class="hljs-string">'BTC,ETH'</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
+client.getIdMap({<span class="hljs-attr">symbol</span>: [<span class="hljs-string">'BTC'</span>, <span class="hljs-string">'ETH'</span>]}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)</pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='getmetadata'>
+      getMetadata
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Get static metadata for one or more cryptocurrencies.
+Either id or symbol is required, but passing in both is not allowed.</p>
+
+
+  <div class='pre p1 fill-light mt0'>getMetadata(args: any, options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>args</span> <code class='quiet'>(any
+            = <code>{}</code>)</code>
+	    
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</code>
+	    Options for the request:
+
+          </div>
+          
+          <table class='mt1 mb2 fixed-table h5 col-12'>
+            <colgroup>
+              <col width='30%' />
+              <col width='70%' />
+            </colgroup>
+            <thead>
+              <tr class='bold fill-light'>
+                <th>Name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody class='mt1'>
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.id</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>)?</code>
+  </td>
+  <td class='break-word'><span>One or more comma separated cryptocurrency IDs
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.symbol</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+  </td>
+  <td class='break-word'><span>One or more comma separated cryptocurrency symbols
+</span></td>
+</tr>
+
+
+              
+            </tbody>
+          </table>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> client = <span class="hljs-keyword">new</span> CoinMarketCap(<span class="hljs-string">'api key'</span>)
+client.getMetadata({<span class="hljs-attr">id</span>: <span class="hljs-string">'1'</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
+client.getMetadata({<span class="hljs-attr">id</span>: [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>]}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
+client.getMetadata({<span class="hljs-attr">symbol</span>: <span class="hljs-string">'BTC,ETH'</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
+client.getMetadata({<span class="hljs-attr">symbol</span>: [<span class="hljs-string">'BTC'</span>, <span class="hljs-string">'ETH]}).then(console.log).catch(console.error)</span></pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='gettickers'>
+      getTickers
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Get information on all tickers.
+Start and limit options can only be used when currency or ID is not given.
+Currency and ID cannot be passed in at the same time.</p>
+
+
+  <div class='pre p1 fill-light mt0'>getTickers(args: any, options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>args</span> <code class='quiet'>(any
+            = <code>{}</code>)</code>
+	    
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</code>
+	    Options for the request
+
+          </div>
+          
+          <table class='mt1 mb2 fixed-table h5 col-12'>
+            <colgroup>
+              <col width='30%' />
+              <col width='70%' />
+            </colgroup>
+            <thead>
+              <tr class='bold fill-light'>
+                <th>Name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody class='mt1'>
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.start</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+  
+    (default <code>1</code>)
+  </td>
+  <td class='break-word'><span>Return results from rank start and above
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.limit</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+  
+    (default <code>100</code>)
+  </td>
+  <td class='break-word'><span>Only returns limit number of results 
+[
+1..5000
+]
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.convert</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+  
+    (default <code>&quot;USD&quot;</code>)
+  </td>
+  <td class='break-word'><span>Return info in terms of another currency
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.sort</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></code>
+  
+    (default <code>&quot;market_cap&quot;</code>)
+  </td>
+  <td class='break-word'><span>Sort results by the options at 
+<a href="https://pro.coinmarketcap.com/api/v1#operation/getV1CryptocurrencyListingsLatest">https://pro.coinmarketcap.com/api/v1#operation/getV1CryptocurrencyListingsLatest</a>
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.sort_dir</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?</code>
+  </td>
+  <td class='break-word'><span>Direction in which to order cryptocurrencies ("asc" | "desc")
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.cryptocurrency_type</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></code>
+  
+    (default <code>&quot;all&quot;</code>)
+  </td>
+  <td class='break-word'><span>Type of cryptocurrency to include ("all" | "coins" | "tokens")
+</span></td>
+</tr>
+
+
+              
+            </tbody>
+          </table>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> client = <span class="hljs-keyword">new</span> CoinMarketCap(<span class="hljs-string">'api key'</span>)
+client.getTickers({<span class="hljs-attr">limit</span>: <span class="hljs-number">3</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
+client.getTickers({<span class="hljs-attr">convert</span>: <span class="hljs-string">'EUR'</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
+client.getTickers({<span class="hljs-attr">start</span>: <span class="hljs-number">0</span>, <span class="hljs-attr">limit</span>: <span class="hljs-number">5</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
+client.getTickers({<span class="hljs-attr">sort</span>: <span class="hljs-string">'name'</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)</pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='getquotes'>
+      getQuotes
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Get latest market quote for 1 or more cryptocurrencies.</p>
+
+
+  <div class='pre p1 fill-light mt0'>getQuotes(args: any, options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>args</span> <code class='quiet'>(any
+            = <code>{}</code>)</code>
+	    
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</code>
+	    Options for the request:
+
+          </div>
+          
+          <table class='mt1 mb2 fixed-table h5 col-12'>
+            <colgroup>
+              <col width='30%' />
+              <col width='70%' />
+            </colgroup>
+            <thead>
+              <tr class='bold fill-light'>
+                <th>Name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody class='mt1'>
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.id</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>)?</code>
+  </td>
+  <td class='break-word'><span>One or more comma separated cryptocurrency IDs
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.symbol</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)?</code>
+  </td>
+  <td class='break-word'><span>One or more comma separated cryptocurrency symbols
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.convert</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+  
+    (default <code>&quot;USD&quot;</code>)
+  </td>
+  <td class='break-word'><span>Return quotes in terms of another currency
+</span></td>
+</tr>
+
+
+              
+            </tbody>
+          </table>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> client = <span class="hljs-keyword">new</span> CoinMarketCap(<span class="hljs-string">'api key'</span>)
+client.getQuotes({<span class="hljs-attr">id</span>: <span class="hljs-string">'1'</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
+client.getQuotes({<span class="hljs-attr">id</span>: [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>], <span class="hljs-attr">convert</span>: <span class="hljs-string">'USD,EUR'</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
+client.getQuotes({<span class="hljs-attr">symbol</span>: <span class="hljs-string">'BTC,ETH'</span>}).then(<span class="hljs-built_in">console</span>.log).catch(<span class="hljs-built_in">console</span>.error)
+client.getQuotes({<span class="hljs-attr">symbol</span>: [<span class="hljs-string">'BTC'</span>, <span class="hljs-string">'ETH]}).then(console.log).catch(console.error)</span></pre>
     
   
 
@@ -412,7 +767,7 @@ client.getTicker({<span class="hljs-attr">convert</span>: <span class="hljs-stri
   <p>Get global information</p>
 
 
-  <div class='pre p1 fill-light mt0'>getGlobal(convert: any, options: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)?)</div>
+  <div class='pre p1 fill-light mt0'>getGlobal(convert: any, options: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)?)</div>
   
   
 
@@ -437,8 +792,8 @@ client.getTicker({<span class="hljs-attr">convert</span>: <span class="hljs-stri
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>options</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)?)</code>
-	    Options for the request
+            <span class='code bold'>options</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)?)</code>
+	    Options for the request:
 
           </div>
           
@@ -456,9 +811,11 @@ client.getTicker({<span class="hljs-attr">convert</span>: <span class="hljs-stri
             <tbody class='mt1'>
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.convert</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?</code>
+  <td class='break-word'><span class='code bold'>options.convert</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+  
+    (default <code>&quot;USD&quot;</code>)
   </td>
-  <td class='break-word'><span>Return price, 24h volume, and market cap in terms of another currency
+  <td class='break-word'><span>Return quotes in terms of another currency
 </span></td>
 </tr>
 

--- a/index.js
+++ b/index.js
@@ -3,23 +3,27 @@
 const fetch = require('node-fetch')
 const qs = require('qs')
 
-const BASE_URL = 'https://api.coinmarketcap.com'
+const BASE_URL = 'https://pro-api.coinmarketcap.com'
 
 class CoinMarketCap {
   /**
    *
+   * @param {String} apiKey API key for accessing the CoinMarketCap API
    * @param {Object=} Options Options for the CoinMarketCap instance
    * @param {String=} options.version  Version of API. Defaults to 'v2'
    * @param {Function=} options.fetcher fetch function to use. Defaults to node-fetch
    * @param {Object=} options.config = Configuration for fetch request
    *
    */
-  constructor ({ version = 'v2', fetcher = fetch, config = {} } = {}) {
+  constructor (apiKey, { version = 'v1', fetcher = fetch, config = {} } = {}) {
+    this.apiKey = apiKey
     this.config = Object.assign({}, {
       method: 'GET',
       headers: {
+        'X-CMC_PRO_API_KEY': this.apiKey,
         Accept: 'application/json',
-        'Accept-Charset': 'utf-8'
+        'Accept-Charset': 'utf-8',
+        'Accept-Encoding': 'deflate, gzip'
       }
     }, config)
 
@@ -28,122 +32,141 @@ class CoinMarketCap {
   }
 
   /**
-   * Get all active cryptocurrency listings
+   * Get a paginated list of all cryptocurrencies by CoinMarketCap ID.
+   *
+   * @param {Object=} options Options for the request:
+   * @param {String=} [options.listingStatus="active"] active or inactive coins
+   * @param {Number|String=} [options.start=1] Return results from rank start and above
+   * @param {Number|String=} options.limit Only returns limit number of results
+   * @param {String[]|String=} options.symbol Comma separated list of symbols, will ignore the other options
    *
    * @example
-   * const client = new CoinMarketCap()
-   * client.getListings().then(console.log).catch(console.error)
+   * const client = new CoinMarketCap('api key')
+   * client.getIdMap().then(console.log).catch(console.error)
+   * client.getIdMap({listingStatus: 'inactive', limit: 10}).then(console.log).catch(console.error)
+   * client.getIdMap({symbol: 'BTC,ETH'}).then(console.log).catch(console.error)
+   * client.getIdMap({symbol: ['BTC', 'ETH']}).then(console.log).catch(console.error)
    */
-  getListings () {
+  getIdMap (args = {}) {
+    let { listingStatus, start, limit, symbol } = args
+
+    if (symbol instanceof Array) {
+      symbol = symbol.join(',')
+    }
+
     return createRequest({
       fetcher: this.fetcher,
-      url: `${this.url}/listings`,
-      config: this.config
+      url: `${this.url}/cryptocurrency/map`,
+      config: this.config,
+      query: { 'listing_status': listingStatus, start, limit, symbol }
     })
   }
 
   /**
-   * Get ticker information.
+   * Get static metadata for one or more cryptocurrencies.
+   * Either id or symbol is required, but passing in both is not allowed.
+   *
+   * @param {Object=} options Options for the request:
+   * @param {Array|String|Number=} options.id One or more comma separated cryptocurrency IDs
+   * @param {String[]|String} options.symbol One or more comma separated cryptocurrency symbols
+   *
+   * @example
+   * const client = new CoinMarketCap('api key')
+   * client.getMetadata({id: '1'}).then(console.log).catch(console.error)
+   * client.getMetadata({id: [1, 2]}).then(console.log).catch(console.error)
+   * client.getMetadata({symbol: 'BTC,ETH'}).then(console.log).catch(console.error)
+   * client.getMetadata({symbol: ['BTC', 'ETH]}).then(console.log).catch(console.error)
+   */
+  getMetadata (args = {}) {
+    return createRequest({
+      fetcher: this.fetcher,
+      url: `${this.url}/cryptocurrency/info`,
+      config: this.config,
+      query: sanitizeIdAndSymbol(args.id, args.symbol)
+    })
+  }
+
+  /**
+   * Get information on all tickers.
    * Start and limit options can only be used when currency or ID is not given.
    * Currency and ID cannot be passed in at the same time.
    *
-   * @param {Object=} options Options for the request:
-   * @param {Number|String=} options.start  Return results from rank start and above
-   * @param {Number|String=} options.limit  Only returns limit number of results
-   * @param {String=} options.sort Sort results by id, rank, volume_24h, or percent_change_24h (default is rank)
-   * @param {String=} options.structure Specify the structure for the main data field. Possible values are dictionary and array (default is dictionary).
-   * @param {String=} options.convert  Return price, 24h volume, and market cap in terms of another currency
-   * @param {String=} options.currency  Return only specific currency
-   * @param {Number=} options.id Return only specific currency associated with its ID from listings
+   * @param {Object=} options Options for the request
+   * @param {Number|String=} [options.start=1] Return results from rank start and above
+   * @param {Number|String=} [options.limit=100] Only returns limit number of results [1..5000]
+   * @param {String[]|String=} [options.convert="USD"] Return info in terms of another currency
+   * @param {String=} [options.sort="market_cap"] Sort results by the options at https://pro.coinmarketcap.com/api/v1#operation/getV1CryptocurrencyListingsLatest
+   * @param {String=} options.sortDir Direction in which to order cryptocurrencies ("asc" | "desc")
+   * @param {String=} [options.cryptocurrencyType="all"] Type of cryptocurrency to include ("all" | "coins" | "tokens")
    *
    * @example
-   * const client = new CoinMarketCap()
-   * client.getTicker({limit: 3}).then(console.log).catch(console.error)
-   * client.getTicker({convert: 'EUR'}).then(console.log).catch(console.error)
-   * client.getTicker({start: 0, limit: 5}).then(console.log).catch(console.error)
-   * client.getTicker({currency: 'BTC'}).then(console.log).catch(console.error)
-   * client.getTicker({convert: 'JPY', id: 2}).then(console.log).catch(console.error)
+   * const client = new CoinMarketCap('api key')
+   * client.getTickers({limit: 3}).then(console.log).catch(console.error)
+   * client.getTickers({convert: 'EUR'}).then(console.log).catch(console.error)
+   * client.getTickers({start: 0, limit: 5}).then(console.log).catch(console.error)
+   * client.getTickers({sort: 'name'}).then(console.log).catch(console.error)
    */
-  async getTicker (args = {}) {
-    let { start, limit, convert, currency, id, structure, sort } = args
-
-    if ((currency || id) && (start || limit || sort)) {
-      throw new Error(
-        'Start, limit, and sort options can only be used when currency or ID is not given.'
-      )
-    }
-    if (currency && id) {
-      throw new Error('Currency and ID cannot be passed in at the same time.')
-    }
+  getTickers (args = {}) {
+    let { start, limit, convert, sort, sortDir, cryptocurrencyType } = args
 
     // eslint-disable-next-line
     if (start && (limit == 0)) {
       throw new Error('Start and limit = 0 cannot be passed in at the same time.')
     }
 
-    if (currency) {
-      let listings = await this.getListings()
-      id = listings.data.find(
-        listing => listing.symbol === currency.toUpperCase()
-      ).id
-    }
-
     // eslint-disable-next-line
     if (limit == 0) {
-      const promises = []
-      const totalCrypto = await this.getTotalActiveCryptocurrencies()
-      const maxLimit = 100
+      limit = 5000
+    }
 
-      for (let start = 1; start <= totalCrypto; start += maxLimit) {
-        promises.push(createRequest({
-          fetcher: this.fetcher,
-          url: `${this.url}/ticker/`,
-          config: this.config,
-          query: { start, structure, convert }
-        }))
-      }
-
-      return Promise.all(promises).then(tickers => {
-        let allTickers
-        let metadata
-
-        structure ? allTickers = [] : allTickers = {}
-
-        tickers.forEach(ticker => {
-          const tickerData = ticker.data
-          metadata = ticker.metadata
-
-          if (structure && Array.isArray(tickerData)) {
-            tickerData.forEach(ticker => {
-              allTickers.push(ticker)
-            })
-          } else {
-            for (const key in tickerData) {
-              allTickers[tickerData[key].id] = tickerData[key]
-            }
-          }
-        })
-
-        return {
-          data: allTickers,
-          metadata
-        }
-      })
+    if (convert && convert instanceof Array) {
+      convert = convert.join(',')
     }
 
     return createRequest({
       fetcher: this.fetcher,
-      url: `${this.url}/ticker/${id ? `${id}/` : ''}`,
+      url: `${this.url}/cryptocurrency/listings/latest}`,
       config: this.config,
-      query: { start, convert, limit, structure, sort }
+      query: { start, limit, convert, sort, 'sort_dir': sortDir, 'cryptocurrency_type': cryptocurrencyType }
+    })
+  }
+
+  /**
+   * Get latest market quote for 1 or more cryptocurrencies.
+   *
+   * @param {Object=} options Options for the request:
+   * @param {Array|String|Number=} options.id One or more comma separated cryptocurrency IDs
+   * @param {String[]|String=} options.symbol One or more comma separated cryptocurrency symbols
+   * @param {String[]|String=} [options.convert="USD"] Return quotes in terms of another currency
+   *
+   * @example
+   * const client = new CoinMarketCap('api key')
+   * client.getQuotes({id: '1'}).then(console.log).catch(console.error)
+   * client.getQuotes({id: [1, 2], convert: 'USD,EUR'}).then(console.log).catch(console.error)
+   * client.getQuotes({symbol: 'BTC,ETH'}).then(console.log).catch(console.error)
+   * client.getQuotes({symbol: ['BTC', 'ETH]}).then(console.log).catch(console.error)
+   */
+  getQuotes (args = {}) {
+    let convert = args.convert
+    let { id, symbol } = sanitizeIdAndSymbol(args.id, args.symbol)
+
+    if (convert instanceof Array) {
+      convert = convert.join(',')
+    }
+
+    return createRequest({
+      fetcher: this.fetcher,
+      url: `${this.url}/cryptocurrency/quotes/latest`,
+      config: this.config,
+      query: { id, symbol, convert }
     })
   }
 
   /**
    * Get global information
    *
-   * @param {Object|String=} options  Options for the request
-   * @param {String=} options.convert  Return price, 24h volume, and market cap in terms of another currency
+   * @param {Object|String[]|String=} options Options for the request:
+   * @param {String[]|String=} [options.convert="USD"] Return quotes in terms of another currency
    *
    * @example
    * const client = new CoinMarketCap()
@@ -151,21 +174,41 @@ class CoinMarketCap {
    * client.getGlobal({convert: 'GBP'}).then(console.log).catch(console.error)
    */
   getGlobal (convert) {
-    if (typeof convert === 'string') {
+    if (typeof convert === 'string' || convert instanceof Array) {
       convert = { convert: convert.toUpperCase() }
+    }
+
+    if (convert.convert instanceof Array) {
+      convert.convert = convert.convert.join(',')
     }
 
     return createRequest({
       fetcher: this.fetcher,
-      url: `${this.url}/global`,
+      url: `${this.url}/global-metrics/quotes/latest`,
       config: this.config,
       query: convert
     })
   }
+}
 
-  getTotalActiveCryptocurrencies () {
-    return this.getGlobal().then(res => res.data.active_cryptocurrencies)
+const sanitizeIdAndSymbol = (id, symbol) => {
+  if (id && symbol) {
+    throw new Error('ID and symbol cannot be passed in at the same time.')
   }
+
+  if (!id && !symbol) {
+    throw new Error('Either ID or symbol is required to be passed in.')
+  }
+
+  if (id instanceof Array) {
+    id = id.join(',')
+  }
+
+  if (symbol instanceof Array) {
+    symbol = symbol.join(',')
+  }
+
+  return { id, symbol }
 }
 
 const createRequest = (args = {}) => {


### PR DESCRIPTION
Made a PR instead of pushing directly because these are breaking changes.

From https://coinmarketcap.com/api/:
> The Public API will be taken offline on December 4th, 2018. Please migrate your application to the free tier of the [Professional API](https://pro.coinmarketcap.com/).

Because of the upcoming deprecation, I rewrote the wrapper for the endpoints that are covered by the free tier of the [Professional API](https://pro.coinmarketcap.com/api/v1#section/Introduction).

[This page](https://pro.coinmarketcap.com/features) shows which endpoints the free tier covers.